### PR TITLE
Fix youtube title is too big and overlay fullscreen button

### DIFF
--- a/Example/YoutubeKit/ViewController.swift
+++ b/Example/YoutubeKit/ViewController.swift
@@ -20,7 +20,8 @@ final class ViewController: UIViewController {
         let parameters: [VideoEmbedParameter] = [
             .playsInline(true),
             .videoID("_6u6UrtXUEI"),
-            .loopVideo(true)
+            .loopVideo(true),
+            .showInfo(false)
         ]
         
         // Create a new player

--- a/YoutubeKit/Player/YTSwiftyConstants.swift
+++ b/YoutubeKit/Player/YTSwiftyConstants.swift
@@ -215,7 +215,10 @@ public enum VideoEmbedParameter {
      In that scenario, the origin parameter identifies the widget provider's domain, but YouTube Analytics should not identify the widget provider as the actual traffic source. Instead, YouTube Analytics uses the widget_referrer parameter value to identify the domain associated with the traffic source.
      */
     case widgetReferrer(String)
-    
+
+    /// Setting the parameter's value to `false` causes the player to not display information like the video title and uploader before the video starts playing. If the player is loading a playlist, and you explicitly set the parameter value to 1, then, upon loading, the player will also display thumbnail images for the videos in the playlist. Note that this functionality is only supported for the AS3 player.
+    case showInfo(Bool)
+
     /// The player parameter.
     public var property: (key: String, value: AnyObject) {
         switch self {
@@ -261,6 +264,8 @@ public enum VideoEmbedParameter {
             return ("rel", relatedVideoPolicy.rawValue as AnyObject)
         case .widgetReferrer(let domain):
             return ("widget_referrer", domain as AnyObject)
+        case .showInfo(let isShow):
+            return ("showinfo", isShow.jsValue)
         }
     }
 }

--- a/YoutubeKit/Player/YTSwiftyPlayerHTML.swift
+++ b/YoutubeKit/Player/YTSwiftyPlayerHTML.swift
@@ -13,7 +13,6 @@ class YTSwiftyPlayerHTML {
         <!DOCTYPE html>
         <html>
         <head>
-        <meta name="viewport" content="width=device-width,initial-scale=1">
         <style>
         html,
         body {
@@ -44,6 +43,13 @@ class YTSwiftyPlayerHTML {
         }
         window.setInterval(updateTime, 500);
         });
+        $(document).ready(function(){
+        var meta = document.createElement('meta');
+        meta.setAttribute('name', 'viewport');
+        meta.setAttribute('content', 'width=device-width');
+        meta.setAttribute('initial-scale', '1');
+        document.getElementsByTagName('head')[0].appendChild(meta);
+        })
         function onReady(event) {
         webkit.messageHandlers.onReady.postMessage('');
         }

--- a/YoutubeKit/Player/YTSwiftyPlayerHTML.swift
+++ b/YoutubeKit/Player/YTSwiftyPlayerHTML.swift
@@ -13,6 +13,7 @@ class YTSwiftyPlayerHTML {
         <!DOCTYPE html>
         <html>
         <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1">
         <style>
         html,
         body {
@@ -43,13 +44,6 @@ class YTSwiftyPlayerHTML {
         }
         window.setInterval(updateTime, 500);
         });
-        $(document).ready(function(){
-        var meta = document.createElement('meta');
-        meta.setAttribute('name', 'viewport');
-        meta.setAttribute('content', 'width=device-width');
-        meta.setAttribute('initial-scale', '1');
-        document.getElementsByTagName('head')[0].appendChild(meta);
-        })
         function onReady(event) {
         webkit.messageHandlers.onReady.postMessage('');
         }


### PR DESCRIPTION
## Descriptions:
It happens on devices with small screen such as iPhone 5s, there is no space for fullscreen button on same row with seek bar.

## Changes:
- 'showinfo = 0' doesn't hide info but it helps to show fullscreen button
- loading `<meta name="viewport">` when loading document causes youtube info (title, watch later and share buttons) become bigger and prevent touching fullscreen button --> load it when document ready